### PR TITLE
Fix style path for release builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn styles() -> String {
 
 #[cfg(not(debug_assertions))]
 fn styles() -> String {
-    grass::include!("../public/style.scss").to_string()
+    grass::include!("public/style.scss").to_string()
 }
 
 fn main() {

--- a/build.rs
+++ b/build.rs
@@ -13,7 +13,7 @@ fn styles() -> String {
 
 #[cfg(not(debug_assertions))]
 fn styles() -> String {
-    grass::include!("../public/style.css").to_string()
+    grass::include!("../public/style.scss").to_string()
 }
 
 fn main() {


### PR DESCRIPTION
Currently `cargo build --release` fails because this file does not exist. Adjusts the path to the one that does exist.

Fixes #5 