### PR TITLE
Fix linux compilation, solving #1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +139,17 @@ name = "atomic-waker"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -381,6 +401,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +455,12 @@ dependencies = [
  "libc",
  "objc",
 ]
+
+[[package]]
+name = "codemap"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e769b5c8c8283982a987c6e948e540254f1058d5a74b8794914d4ef5fc2a24"
 
 [[package]]
 name = "codespan-reporting"
@@ -614,7 +655,7 @@ dependencies = [
  "dtoa-short",
  "itoa 0.4.8",
  "matches",
- "phf",
+ "phf 0.8.0",
  "proc-macro2",
  "quote",
  "smallvec",
@@ -723,7 +764,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn",
 ]
 
@@ -1100,6 +1141,7 @@ dependencies = [
  "flume",
  "futures-channel",
  "futures-util",
+ "grass",
  "html5gum",
  "id_tree",
  "im",
@@ -1738,6 +1780,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "grass"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cc4b64880a2264a41f9eab431780e72a68a6c88b9bddef361ba638812d572e"
+dependencies = [
+ "clap",
+ "grass_compiler",
+ "include_sass",
+]
+
+[[package]]
+name = "grass_compiler"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4feeef87d958eebd4d55431040768b93a5b088202198e0b203adc3c1d468c6"
+dependencies = [
+ "codemap",
+ "indexmap",
+ "lasso",
+ "once_cell",
+ "phf 0.10.1",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "gtk"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +1889,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -1834,6 +1910,15 @@ name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -2072,13 +2157,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_sass"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d943fc585185af6fd7bc4a86606c3c68b62ec2633897ac83bceb3f65125d2e7f"
+dependencies = [
+ "grass_compiler",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2125,7 +2221,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a798d7677f07d6f1e77be484ea8626ddb1566194de399f1206306820c406371"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
  "parking_lot",
 ]
 
@@ -2357,6 +2453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lasso"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb7b21a526375c5ca55f1a6dfd4e1fad9fa4edd750f530252a718a44b2608f0"
+dependencies = [
+ "hashbrown 0.11.2",
+]
+
+[[package]]
 name = "lazy-bytes-cast"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,7 +2575,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2495,7 +2600,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd"
 dependencies = [
  "log",
- "phf",
+ "phf 0.8.0",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -2609,9 +2714,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c820db003e601413e835a33b10cf51452b6415ef34ff1d862401826431c675"
+checksum = "a0b141f55dd7831b7c1c0e9551165f6eee87021a356a437c00f3bdc2aeafc3ec"
 dependencies = [
  "cocoa",
  "crossbeam-channel",
@@ -3077,8 +3182,19 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.8.0",
  "phf_shared 0.8.0",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_macros 0.10.0",
+ "phf_shared 0.10.0",
  "proc-macro-hack",
 ]
 
@@ -3120,6 +3236,20 @@ checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
 dependencies = [
  "phf_generator 0.8.0",
  "phf_shared 0.8.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -3719,7 +3849,7 @@ dependencies = [
  "fxhash",
  "log",
  "matches",
- "phf",
+ "phf 0.8.0",
  "phf_codegen",
  "precomputed-hash",
  "servo_arc",
@@ -4081,6 +4211,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -4218,6 +4354,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -4569,6 +4714,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2391,6 +2391,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "libxdo"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00333b8756a3d28e78def82067a377de7fa61b24909000aeaa2b446a948d14db"
+dependencies = [
+ "libxdo-sys",
+]
+
+[[package]]
+name = "libxdo-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
+dependencies = [
+ "libc",
+ "x11",
+]
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,17 +2609,22 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.4.0"
-source = "git+https://github.com/terhechte/muda.git?branch=macos_fixes#00b2a9048729c394db2dce835cd855423284ad5c"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c820db003e601413e835a33b10cf51452b6415ef34ff1d862401826431c675"
 dependencies = [
  "cocoa",
  "crossbeam-channel",
+ "gdk",
+ "gdk-pixbuf",
+ "gtk",
  "keyboard-types",
+ "libxdo",
  "objc",
  "once_cell",
  "png",
  "thiserror",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,7 @@ megalodon = { git = "https://github.com/terhechte/megalodon-rs", branch = "tempo
 tokio = { version = "1.16.1", features = ["full"] }
 dioxus-desktop = { git = "https://github.com/terhechte/dioxus.git", branch = "dioxus_macos_hacks"}
 webbrowser = "0.8.9"
-# muda = { git = "https://github.com/terhechte/muda.git", branch = "macos_fixes" }
-muda = "0.5.0"
+muda = "0.6.0"
 cocoa = "0.24"
 objc = "0.2"
 cacao = { git = "https://github.com/terhechte/cacao", branch = "segmented_control_icons_toolbar" }
@@ -78,8 +77,7 @@ megalodon = { git = "https://github.com/terhechte/megalodon-rs", branch = "tempo
 tokio = { version = "1.16.1", features = ["full"] }
 dioxus-desktop = { git = "https://github.com/terhechte/dioxus.git", branch = "dioxus_macos_hacks"}
 webbrowser = "0.6.0"
-# muda = { git = "https://github.com/terhechte/muda.git", branch = "macos_fixes" }
-muda = "0.5.0"
+muda = "0.6.0"
 image = { version = "0.24.5", features = ["jpeg"] }
 directories-next = "2.0.0"
 current_locale = "0.1.1"
@@ -100,7 +98,7 @@ wasm-logger = "0.2.0"
 megalodon = { git = "https://github.com/terhechte/megalodon-rs", branch = "temporary_both"}
 tokio = { version = "1.16.1", features = ["full"] }
 dioxus-desktop = { git = "https://github.com/terhechte/dioxus.git", branch = "dioxus_macos_hacks"}
-muda = "0.5.0"
+muda = "0.6.0"
 webbrowser = "0.6.0"
 image = { version = "0.24.5", features = ["jpeg"] }
 directories-next = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,8 @@ megalodon = { git = "https://github.com/terhechte/megalodon-rs", branch = "tempo
 tokio = { version = "1.16.1", features = ["full"] }
 dioxus-desktop = { git = "https://github.com/terhechte/dioxus.git", branch = "dioxus_macos_hacks"}
 webbrowser = "0.8.9"
-muda = { git = "https://github.com/terhechte/muda.git", branch = "macos_fixes" }
+# muda = { git = "https://github.com/terhechte/muda.git", branch = "macos_fixes" }
+muda = "0.5.0"
 cocoa = "0.24"
 objc = "0.2"
 cacao = { git = "https://github.com/terhechte/cacao", branch = "segmented_control_icons_toolbar" }
@@ -77,7 +78,8 @@ megalodon = { git = "https://github.com/terhechte/megalodon-rs", branch = "tempo
 tokio = { version = "1.16.1", features = ["full"] }
 dioxus-desktop = { git = "https://github.com/terhechte/dioxus.git", branch = "dioxus_macos_hacks"}
 webbrowser = "0.6.0"
-muda = { git = "https://github.com/terhechte/muda.git", branch = "macos_fixes" }
+# muda = { git = "https://github.com/terhechte/muda.git", branch = "macos_fixes" }
+muda = "0.5.0"
 image = { version = "0.24.5", features = ["jpeg"] }
 directories-next = "2.0.0"
 current_locale = "0.1.1"
@@ -93,6 +95,18 @@ wasm-bindgen = "0.2.83"
 wasm-bindgen-futures = "*"
 dioxus-web = { git = "https://github.com/terhechte/dioxus.git", branch = "dioxus_macos_hacks"}
 wasm-logger = "0.2.0"
+
+[target."cfg(target_os = \"linux\")".dependencies]
+megalodon = { git = "https://github.com/terhechte/megalodon-rs", branch = "temporary_both"}
+tokio = { version = "1.16.1", features = ["full"] }
+dioxus-desktop = { git = "https://github.com/terhechte/dioxus.git", branch = "dioxus_macos_hacks"}
+muda = "0.5.0"
+webbrowser = "0.6.0"
+image = { version = "0.24.5", features = ["jpeg"] }
+directories-next = "2.0.0"
+current_locale = "0.1.1"
+sha2 = "0.10.6"
+env_logger = "0.10.0"
 
 [profile.release]
 debug = true

--- a/src/environment/native/platform.rs
+++ b/src/environment/native/platform.rs
@@ -20,6 +20,11 @@ mod windows;
 #[cfg(target_os = "windows")]
 pub use self::windows::*;
 
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+pub use self::linux::*;
+
 pub fn is_fullscreen<'a>(window: &'a AppWindow<'a>) -> bool {
     window.fullscreen().is_some()
 }

--- a/src/environment/native/platform/linux.rs
+++ b/src/environment/native/platform/linux.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use dioxus::prelude::ScopeState;
+use dioxus_desktop::{LogicalSize, WindowBuilder};
+
+pub use navicula::types::AppWindow;
+
+use crate::environment::{
+    storage::UiTab,
+    types::{ActionFromEvent, AppEvent, MainMenuConfig},
+};
+
+pub fn default_window() -> WindowBuilder {
+    let builder = WindowBuilder::new();
+    let s = LogicalSize::new(1200., 775.);
+
+    let builder = builder
+        .with_title("Ebou")
+        .with_theme(Some(dioxus_desktop::tao::window::Theme::Dark))
+        .with_inner_size(s);
+    builder
+}
+
+#[derive(Clone, Default)]
+pub struct Platform {}
+
+impl Platform {
+    pub fn setup_toolbar(&self, _window: &AppWindow) {}
+    pub fn update_menu<'a>(&self, _window: &AppWindow, _mutator: impl Fn(&mut MainMenuConfig)) {}
+    pub fn update_toolbar(
+        &self,
+        _account: &str,
+        _window: &AppWindow,
+        _tab: &UiTab,
+        _has_notifications: bool,
+    ) {
+    }
+    pub fn handle_menu_events<A: ActionFromEvent + 'static>(
+        &self,
+        _cx: &ScopeState,
+        _updater: Arc<dyn Fn(A) + Send + Sync>,
+    ) {
+    }
+    pub fn set_toolbar_handler(&self, _handler: std::sync::Arc<dyn Fn(AppEvent) + Send + Sync>) {}
+    pub fn loggedout_toolbar(&self, _window: &AppWindow) {}
+}
+
+pub fn apply_window_background<'a>(window: &AppWindow) {
+    let webview = window.webview.clone();
+    let native_window = webview.window();
+
+    // use window_vibrancy::apply_blur;
+    // apply_blur(&native_window, Some((18, 18, 18, 125)))
+    //     .expect("Unsupported platform! 'apply_blur' is only supported on Windows");
+}

--- a/src/widgets/buttons.rs
+++ b/src/widgets/buttons.rs
@@ -15,6 +15,7 @@ pub fn EmojiButton(cx: Scope<'_>) -> Element<'_> {
                 button {
                     prevent_default: "onmousedown",
                     onmousedown: move |_| {
+                        #[cfg(not(target_os = "linux"))]
                         crate::environment::platform::show_emoji_popup(&window);
                     },
                     dangerous_inner_html: crate::icons::ICON_EMOJI


### PR DESCRIPTION
This PR fixes linux compilation, it adds a new platform file (`linux.rs`) and `target_os` dependencies for linux in Cargo.toml. Due to how Rust handles dependencies when using the same crate for different `target_os` in Cargo.toml need to be the same version, this is why `muda` version was also changed in this PR for Windows and MacOS.