### PR TITLE
remove warning, add attach button

### DIFF
--- a/src/components/post/view.rs
+++ b/src/components/post/view.rs
@@ -83,9 +83,7 @@ fn ToolbarView<'a>(cx: Scope<'a>, store: &'a ViewStore<'a>) -> Element<'a> {
         is_posting_class = "true";
     }
 
-    let current = store
-        .visibility
-        .unwrap_or(super::Visibility::Public);
+    let current = store.visibility.unwrap_or(super::Visibility::Public);
     let is_direct = current == super::Visibility::Direct;
 
     cx.render(rsx!(
@@ -127,6 +125,13 @@ fn ToolbarView<'a>(cx: Scope<'a>, store: &'a ViewStore<'a>) -> Element<'a> {
                     selected: "{is_direct}",
                     value: "direct", "Mentioned people only",
                 }
+            }
+            button {
+                class: "button me-3",
+                disabled: is_posting_class,
+                r#type: "file",
+                onclick: move |_| store.send(PostAction::FileDialog),
+                "Attach"
             }
             button {
                 class: "button me-2 highlighted",

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,1 +1,1 @@
-pub const STYLE: &'static str = include_str!(concat!(env!("OUT_DIR"), "/style.css"));
+pub const STYLE: &str = include_str!(concat!(env!("OUT_DIR"), "/style.css"));


### PR DESCRIPTION
Adds a "Attach" button to attach media to a post

<img width="532" alt="Screenshot 2023-07-04 at 12 27 17" src="https://github.com/terhechte/Ebou/assets/132234/469981aa-6ce9-46c6-be03-db9897174b2a">
