### PR TITLE
[Do Not Merge] display more errors

### DIFF
--- a/src/components/login/reducer.rs
+++ b/src/components/login/reducer.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::{cell::RefCell, fmt::Error};
 
 use crate::environment::{
     model::{Account, AppData, Model, TokenData},
@@ -116,7 +116,9 @@ pub fn reduce<'a>(
                 Ok(n) => {
                     state.model = Some(ModelContainer::new(n.id.clone(), model));
                     if let Some(ref url) = n.url {
-                        environment.open_url(url)
+                        _ = webbrowser::open(url).or_else(|err| {
+                            std::io::Result::Ok(state.error_message = Some(format!("Could not open browser: {err:?}")))
+                        });
                     }
                     state.app_data = Some(n);
                 }

--- a/src/components/login/reducer.rs
+++ b/src/components/login/reducer.rs
@@ -115,11 +115,13 @@ pub fn reduce<'a>(
             match result {
                 Ok(n) => {
                     state.model = Some(ModelContainer::new(n.id.clone(), model));
-                    if let Some(ref url) = n.url {
-                        _ = webbrowser::open(url).or_else(|err| {
-                            std::io::Result::Ok(state.error_message = Some(format!("Could not open browser: {err:?}")))
-                        });
-                    }
+                    state.error_message = n.url.as_ref()
+                        .map_or_else(|| Some(format!("no login URL provided")),
+                        |ref tokenUrl| { 
+                        webbrowser::open(tokenUrl)
+                                    .map_or_else(|e| Some(format!("could not open browser: {e:?}")),
+                                        |_| None)
+                    });
                     state.app_data = Some(n);
                 }
                 Err(e) => state.error_message = Some(format!("Mastodon Error: {e:?}")),

--- a/src/components/login/view.rs
+++ b/src/components/login/view.rs
@@ -305,8 +305,12 @@ fn Page2<'a>(
                     style: "text-decoration: underline; cursor: pointer;",
                     onclick: move |_| {
                         if let Some(url) = view_store.app_data.as_ref().and_then(|e| e.url.clone()) {
-                             let mut ctx = copypasta::ClipboardContext::new().expect("could not open clipboard context");
-                             let _ = ctx.set_contents(url);
+                             _ = match copypasta::ClipboardContext::new() {
+                                Ok(mut ctx) => ctx.set_contents(url).map_or_else(
+                                    |e| Some(format!("could not copy url: {e:?}")),
+                                    |_| None),
+                                Err(e) => Some(format!("could not access clipboard: {e:?}"))
+                            };
                         }
                     },
                     loc!("Copy the browser URL to the clipboard")

--- a/src/components/login/view.rs
+++ b/src/components/login/view.rs
@@ -305,9 +305,8 @@ fn Page2<'a>(
                     style: "text-decoration: underline; cursor: pointer;",
                     onclick: move |_| {
                         if let Some(url) = view_store.app_data.as_ref().and_then(|e| e.url.clone()) {
-                            if let Ok(mut ctx) = copypasta::ClipboardContext::new() {
-                                let _ = ctx.set_contents(url);
-                            }
+                             let mut ctx = copypasta::ClipboardContext::new().expect("could not open clipboard context");
+                             let _ = ctx.set_contents(url);
                         }
                     },
                     loc!("Copy the browser URL to the clipboard")

--- a/src/environment/native/mod.rs
+++ b/src/environment/native/mod.rs
@@ -64,7 +64,7 @@ impl Environment {
     }
 
     pub fn open_url(&self, url: &str) {
-        let _ = webbrowser::open(url);
+        webbrowser::open(url).expect("could not open browser");
     }
 
     pub fn open_window<S: OpenWindowState + 'static, Action: 'static>(

--- a/src/environment/native/mod.rs
+++ b/src/environment/native/mod.rs
@@ -64,7 +64,7 @@ impl Environment {
     }
 
     pub fn open_url(&self, url: &str) {
-        webbrowser::open(url).expect("could not open browser");
+        let _ = webbrowser::open(url);
     }
 
     pub fn open_window<S: OpenWindowState + 'static, Action: 'static>(


### PR DESCRIPTION
@terhechte thank you so much for building a mastodon client in Rust!

I'm very interested in using Ebou and contributing to the project.

As an Arch Linux/Wayland user I discovered a number of items that don't "work out of the box". Digging into them some were easy to solve, and some like wayland clipboard support were not.

Because many of the errors were "thrown away" it was a bit more challenging to discover what was going on.

:point_right: I would like to expose more of these errors to users to help folks troubleshoot these issues. I'm not entirely sure how to easily expose these errors to the client, so I thought I would open a PR while I try to figure it out in case there's a system you're using.

In general it comes down to changing the `view_store` or the `state` `error_message`. If you assign the `error_message` to `None` no error message will display.

```rust
state.error_message = do_thing.map_or_else(
//error
|| Some(format!("error message"),
 //success
 |_| None)
```