### PR TITLE
Update ahash to fix yanked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom 0.2.8",
  "once_cell",


### PR DESCRIPTION
The version of `ahash` currently stored in `Cargo.lock` is yanked from crates.io because it fails to compile. Additionally, this crate fails to compile when installed via `cargo install --git` because of some weird confusion about which version of `gdk-sys` to use (I'm not quite certain what's causing that issue), but that issue can be worked around by passing in the `--locked` flag to the `cargo install` invocation. However, this also fails to build when using the `--locked` flag because of that yanked ahash version. So I'm just updating it here so that this crate is installable via `cargo install --git`.